### PR TITLE
tests: Fix the `docker run` command (for test validator) on macOS

### DIFF
--- a/runTest.sh
+++ b/runTest.sh
@@ -17,8 +17,22 @@ solana config set --url http://localhost:8899
 docker rm -f solana-validator || true
     docker run -d \
         --name solana-validator \
-        --net=host \
         --pull=always \
+        -p 8899:8899 \
+        -p 8900:8900 \
+        -p 8901:8901 \
+        -p 8902:8902 \
+        -p 9900:9900 \
+        -p 8000:8000 \
+        -p 8001:8001 \
+        -p 8002:8002 \
+        -p 8003:8003 \
+        -p 8004:8004 \
+        -p 8005:8005 \
+        -p 8006:8006 \
+        -p 8007:8007 \
+        -p 8008:8008 \
+        -p 8009:8009 \
         -v $HOME/.config/solana/id.json:/root/.config/solana/id.json \
         ghcr.io/lightprotocol/solana-test-validator:main \
         --reset \


### PR DESCRIPTION
`--net=host` option works as expected only on Linux, where Docker is used without any virtualization laver. On macOS, Docker runs inside a VM, so we need to map the ports explicitly. That way, Docker on macOS knows which ports to map first from the container to the VM, then from the VM to the host system.